### PR TITLE
Refactored CRC code

### DIFF
--- a/crc_errors/CRC_Count_check.py
+++ b/crc_errors/CRC_Count_check.py
@@ -7,8 +7,8 @@ import logging
 from tabulate import tabulate
 
 # Needed for aetest script
-from ats import aetest
-from ats.log.utils import banner
+from pyats import aetest
+from pyats.log.utils import banner
 
 # Genie Imports
 from genie.testbed import load
@@ -16,7 +16,6 @@ from genie.testbed import load
 
 # Get your logger for your script
 log = logging.getLogger(__name__)
-
 
 ###################################################################
 #                  COMMON SETUP SECTION                           #
@@ -36,105 +35,88 @@ class common_setup(aetest.CommonSetup):
                 f"Connect to device '{device.name}'"))
             try:
                 device.connect()
+                device_list.append(device)
             except Exception as e:
-                self.failed(f"Failed to establish connection to '{device.name}'")
+                log.info(f"Failed to establish connection to '{device.name}'")
 
-            device_list.append(device)
-
-        # Pass list of devices the to testcases
         self.parent.parameters.update(dev=device_list)
-        print(self.parent.parameters)
+        log.debug(self.parent.parameters)
+
+    @aetest.subsection
+    def create_testcases(self):
+        #below creates a loop over the CRC_count_Check Class using dev as the iterator
+        aetest.loop.mark(CRC_count_Check, dev=self.parent.parameters['dev'])
+
+class CRC_count_Check(aetest.Testcase):
+    @aetest.setup
+    def setup(self, dev):
+        #Setup has been marked for looping in Common Setup(create_testcases) with the argument dev
+        #dev is the list of devices in the current testbed
+        log.info(banner(f"Gathering Interface Information from {dev.name}"))
+        self.interface_info = dev.learn('interface')
 
 
-###################################################################
-#                     TESTCASES SECTION                           #
-###################################################################
-
-# Testcase name : Check for CRC errors
-class CRC_count_check(aetest.Testcase):
-    """ This is user Testcases section """
-
-    # First test section
-    @ aetest.test
-    def learn_interfaces(self):
-
-        self.all_interfaces = {}
-        for dev in self.parent.parameters['dev']:
-            log.info(banner(f"Gathering Interface Information from {dev.name}"))
-            intf = dev.learn('interface')
-            self.all_interfaces[dev.name] = intf.info
-
-    # Second test section
-    @ aetest.test
-    def check_CRC(self):
-
+        list_of_interfaces=self.interface_info.info.keys()
         mega_dict = {}
+        mega_dict[dev.name] = {}
         mega_tabular = []
-        for device, ints in self.all_interfaces.items():
-            mega_dict[device] = {}
-            for name, props in ints.items():
-                counters = props.get('counters')
-                if counters:
-                    smaller_tabular = []
-                    if 'in_crc_errors' in counters:
-                        mega_dict[device][name] = counters['in_crc_errors']
-                        smaller_tabular.append(device)
-                        smaller_tabular.append(name)
-                        smaller_tabular.append(str(counters['in_crc_errors']))
-                        if counters['in_crc_errors']:
-                            smaller_tabular.append('Failed')
-                        else:
-                            smaller_tabular.append('Passed')
+        passing=0
+
+
+        for ints, props in self.interface_info.info.items():
+            counters = props.get('counters')
+            if counters:
+                smaller_tabular = []
+                if 'in_crc_errors' in counters:
+                    mega_dict[dev.name][ints] = counters['in_crc_errors']
+                    smaller_tabular.append(dev.name)
+                    smaller_tabular.append(ints)
+                    smaller_tabular.append(str(counters['in_crc_errors']))
+                    if counters['in_crc_errors']:
+                        smaller_tabular.append('Failed')
+                        passing=1
                     else:
-                        mega_dict[device][name] = None
-                        smaller_tabular.append(device)
-                        smaller_tabular.append(name)
-                        smaller_tabular.append('N/A')
-                        smaller_tabular.append('N/A')
-                mega_tabular.append(smaller_tabular)
+                        smaller_tabular.append('Passed')
 
-        mega_tabular.append(['-'*sum(len(i) for i in smaller_tabular)])
+                else:
+                    mega_dict[dev.name][ints] = None
+                    smaller_tabular.append(dev.name)
+                    smaller_tabular.append(ints)
+                    smaller_tabular.append('N/A')
+                    smaller_tabular.append('N/A')
+            mega_tabular.append(smaller_tabular)
+        mega_tabular.append(['-' * sum(len(i) for i in smaller_tabular)])
 
-        log.info(tabulate(mega_tabular,
+        #pass megadict to interface test function
+        self.parent.parameters.update(mega=mega_dict[dev.name])
+        #pass megatable list to table_display test function
+        self.parent.parameters.update(megatable=mega_tabular)
+        #pass passing variable to table_display function in order indicate pass or fail - 0=pass 1=fail
+        self.parent.parameters.update(passing=passing)
+
+        aetest.loop.mark(self.interface_check, intf=list_of_interfaces)
+
+    @aetest.test
+    def table_display(self):
+        log.info(tabulate(self.parent.parameters['megatable'],
                           headers=['Device', 'Interface',
                                    'CRC Errors Counter',
                                    'Passed/Failed'],
                           tablefmt='orgtbl'))
 
-        for dev in mega_dict:
-            for intf in mega_dict[dev]:
-                if mega_dict[dev][intf]:
-                    self.failed(f"{dev}: {intf} CRC ERRORS: {mega_dict[dev][intf]}")
+        if self.parent.parameters['passing']==1:
+            self.failed('Some interfaces have CRC errors')
+        else:
+            self.passed
 
-        self.passed("All devices' interfaces CRC ERRORS Count is: 'Zero'")
-
-# #####################################################################
-# ####                       COMMON CLEANUP SECTION                 ###
-# #####################################################################
-
-
-# This is how to create a CommonCleanup
-# You can have 0 , or 1 CommonCleanup.
-# CommonCleanup can be named whatever you want :)
-class common_cleanup(aetest.CommonCleanup):
-    """ Common Cleanup for Sample Test """
-
-    # CommonCleanup follow exactly the same rule as CommonSetup regarding
-    # subsection
-    # You can have 1 to as many subsections as wanted
-    # here is an example of 1 subsection
-
-    # @aetest.subsection
-    # def clean_everything(self):
-    #     """ Common Cleanup Subsection """
-    #     log.info("Aetest Common Cleanup ")
-    @aetest.subsection
-
-    def disconnect(self):
-        log.info("Aetest Common Cleanup disconnecting devices")
-        for dev in self.parent.parameters['dev']:
-            dev.disconnect()
+    @aetest.test
+    def interface_check(self, intf):
+        # This test has been marked for loop.  intf is the looping argument (list of interfaces)
+        # Thus this test is run for each interface in the intf list.
+        for int, errors in self.parent.parameters['mega'].items():
+            if errors:
+                self.failed(f'Interface {int} has crc errors {errors}')
+            else:
+                self.passed(f'No errors on {int}')
 
 
-if __name__ == '__main__':  # pragma: no cover
-    aetest.main()

--- a/crc_errors/CRC_Count_check.py
+++ b/crc_errors/CRC_Count_check.py
@@ -96,13 +96,6 @@ class CRC_count_Check(aetest.Testcase):
             self.mega_tabular.append(smaller_tabular)
         self.mega_tabular.append(['-' * sum(len(i) for i in smaller_tabular)])
 
-        #pass megadict to interface test function
-        #self.parent.parameters.update(mega=mega_dict[dev.name])
-        #self.megadictname=self.mega_dict[dev.name])
-        #pass megatable list to table_display test function
-       # self.parent.parameters.update(megatable=self.mega_tabular)
-        #pass self.passing variable to table_display function in order indicate pass or fail - 0=pass 1=fail
-        #self.parent.parameters.update(passing=self.passing)
 
         aetest.loop.mark(self.interface_check, intf=list_of_interfaces)
 
@@ -110,7 +103,6 @@ class CRC_count_Check(aetest.Testcase):
 # which means there are some CRC errors
     @aetest.test
     def table_display(self):
-        #log.info(tabulate(self.parent.parameters['megatable'],
         log.info(tabulate(self.mega_tabular,
                           headers=['Device', 'Interface',
                                    'CRC Errors Counter',

--- a/crc_errors/CRC_Count_check.py
+++ b/crc_errors/CRC_Count_check.py
@@ -47,6 +47,15 @@ class common_setup(aetest.CommonSetup):
         #below creates a loop over the CRC_count_Check Class using dev as the iterator
         aetest.loop.mark(CRC_count_Check, dev=self.parent.parameters['dev'])
 
+
+
+###################################################################
+#                     TESTCASES SECTION                           #
+###################################################################
+
+#Capture Interfaces statistics on the device and tabulate
+#Also look for CRC Errors. If CRC Errors fail then change
+#variable 'passing' from 0 to 1
 class CRC_count_Check(aetest.Testcase):
     @aetest.setup
     def setup(self, dev):
@@ -96,6 +105,8 @@ class CRC_count_Check(aetest.Testcase):
 
         aetest.loop.mark(self.interface_check, intf=list_of_interfaces)
 
+# create table and display. Test fails if variable 'passing' = 1.
+# which means there are some CRC errors
     @aetest.test
     def table_display(self):
         log.info(tabulate(self.parent.parameters['megatable'],
@@ -109,6 +120,7 @@ class CRC_count_Check(aetest.Testcase):
         else:
             self.passed
 
+# Test created for each interface. If CRC errors then Interface test will fail
     @aetest.test
     def interface_check(self, intf):
         # This test has been marked for loop.  intf is the looping argument (list of interfaces)
@@ -120,3 +132,29 @@ class CRC_count_Check(aetest.Testcase):
                 self.passed(f'No errors on {int}')
 
 
+# #####################################################################
+# ####                       COMMON CLEANUP SECTION                 ###
+# #####################################################################
+
+
+# This is how to create a CommonCleanup
+# You can have 0 , or 1 CommonCleanup.
+# CommonCleanup can be named whatever you want :)
+class common_cleanup(aetest.CommonCleanup):
+    """ Common Cleanup for Sample Test """
+
+    # CommonCleanup follow exactly the same rule as CommonSetup regarding
+    # subsection
+    # You can have 1 to as many subsections as wanted
+    # here is an example of 1 subsection
+
+    @aetest.subsection
+
+    def disconnect(self):
+        log.info("Aetest Common Cleanup disconnecting devices")
+        for dev in self.parent.parameters['dev']:
+            dev.disconnect()
+
+
+if __name__ == '__main__':  # pragma: no cover
+    aetest.main()

--- a/crc_errors/CRC_Count_check.py
+++ b/crc_errors/CRC_Count_check.py
@@ -61,15 +61,15 @@ class CRC_count_Check(aetest.Testcase):
     def setup(self, dev):
         #Setup has been marked for looping in Common Setup(create_testcases) with the argument dev
         #dev is the list of devices in the current testbed
+        self.dev = dev
         log.info(banner(f"Gathering Interface Information from {dev.name}"))
         self.interface_info = dev.learn('interface')
 
-
         list_of_interfaces=self.interface_info.info.keys()
-        mega_dict = {}
-        mega_dict[dev.name] = {}
-        mega_tabular = []
-        passing=0
+        self.mega_dict = {}
+        self.mega_dict[dev.name] = {}
+        self.mega_tabular = []
+        self.passing=0
 
 
         for ints, props in self.interface_info.info.items():
@@ -77,31 +77,32 @@ class CRC_count_Check(aetest.Testcase):
             if counters:
                 smaller_tabular = []
                 if 'in_crc_errors' in counters:
-                    mega_dict[dev.name][ints] = counters['in_crc_errors']
+                    self.mega_dict[dev.name][ints] = counters['in_crc_errors']
                     smaller_tabular.append(dev.name)
                     smaller_tabular.append(ints)
                     smaller_tabular.append(str(counters['in_crc_errors']))
                     if counters['in_crc_errors']:
                         smaller_tabular.append('Failed')
-                        passing=1
+                        self.passing=1
                     else:
                         smaller_tabular.append('Passed')
 
                 else:
-                    mega_dict[dev.name][ints] = None
+                    self.mega_dict[dev.name][ints] = None
                     smaller_tabular.append(dev.name)
                     smaller_tabular.append(ints)
                     smaller_tabular.append('N/A')
                     smaller_tabular.append('N/A')
-            mega_tabular.append(smaller_tabular)
-        mega_tabular.append(['-' * sum(len(i) for i in smaller_tabular)])
+            self.mega_tabular.append(smaller_tabular)
+        self.mega_tabular.append(['-' * sum(len(i) for i in smaller_tabular)])
 
         #pass megadict to interface test function
-        self.parent.parameters.update(mega=mega_dict[dev.name])
+        #self.parent.parameters.update(mega=mega_dict[dev.name])
+        #self.megadictname=self.mega_dict[dev.name])
         #pass megatable list to table_display test function
-        self.parent.parameters.update(megatable=mega_tabular)
-        #pass passing variable to table_display function in order indicate pass or fail - 0=pass 1=fail
-        self.parent.parameters.update(passing=passing)
+       # self.parent.parameters.update(megatable=self.mega_tabular)
+        #pass self.passing variable to table_display function in order indicate pass or fail - 0=pass 1=fail
+        #self.parent.parameters.update(passing=self.passing)
 
         aetest.loop.mark(self.interface_check, intf=list_of_interfaces)
 
@@ -109,13 +110,14 @@ class CRC_count_Check(aetest.Testcase):
 # which means there are some CRC errors
     @aetest.test
     def table_display(self):
-        log.info(tabulate(self.parent.parameters['megatable'],
+        #log.info(tabulate(self.parent.parameters['megatable'],
+        log.info(tabulate(self.mega_tabular,
                           headers=['Device', 'Interface',
                                    'CRC Errors Counter',
                                    'Passed/Failed'],
                           tablefmt='orgtbl'))
 
-        if self.parent.parameters['passing']==1:
+        if self.passing==1:
             self.failed('Some interfaces have CRC errors')
         else:
             self.passed
@@ -125,7 +127,8 @@ class CRC_count_Check(aetest.Testcase):
     def interface_check(self, intf):
         # This test has been marked for loop.  intf is the looping argument (list of interfaces)
         # Thus this test is run for each interface in the intf list.
-        for int, errors in self.parent.parameters['mega'].items():
+        #for int, errors in self.parent.parameters['mega'].items():
+        for int, errors in self.mega_dict[self.dev.name].items():
             if errors:
                 self.failed(f'Interface {int} has crc errors {errors}')
             else:


### PR DESCRIPTION
Highlights of changes

* If Device fails to connect then script will not fail and thus not block
* Only Devices that have successfully connected will be tested
* Table creation is it's own test, and will fail on crc errors
* Looping over CRC_Count for each device
* Looping over interface test to provide test for each interface.

Might not be the most elegant, and no doubt room for improvement, but it works as expected.