### PR TITLE
Adding YANG telemetry test example using Blitz trigger class.

### DIFF
--- a/blitz_yang_telemetry/README.md
+++ b/blitz_yang_telemetry/README.md
@@ -1,0 +1,32 @@
+Examples
+========
+
+This directory contains working examples run against Cisco devices.
+
+The testbed file has an XE Cat9K, and a Nexus 9k setup (Fake IP addresses).
+The mapping file allows you to filter out the device you want to test.
+The test_trigger_extended "data" file contains various xpath, namespace, and values that extends the test_trigger.
+The test_trigger file contains the actual definitions of the test and extends the data file.
+The job file is an example of how to choose exactly which test you wish to run.
+
+Main points to get your test running.
+
+- Testbed file device name must match the configured "host" name of the device.
+- TLS certificates will be needed if you are testing secure connections (see testbed file).
+- TLS certificate host override setting, if added to certificate, must be added to host file or DNS.
+- Mapping file must match the device name or alias you want to test in the testbed file.
+- Data file may need device name/connection of mapping file and the protocol used in test.
+- Job file, uncomment tests you want to run, comment out tests you don't want to run.
+
+Tests in test file:
+
+- device_cleanup - Not called in job file but there as an example.
+- native_oper_interface_statistics_get - An XE NETCONF get of interface statistics with returned values verified.
+- openconfig_gnmi_fan_statistics_subscribe - An XE gNMI SAMPLE subscription which receives fan speed every 5 seconds and verifies value.
+- native_netconf_cpu_statistics_subscribe - An XE NETCONF SAMPLE subscription which receives CPU five-minute statistic every 5 seconds and verifies value.
+- nexus_openconfig_gnmi_fan_statistics_subscribe - An NX gNMI SAMPLE subscription which receives fan speed every 5 seconds and verifies value.
+- nexus_netconf_interface_state_subscribe - An NX NETCONF ON_CHANGE subscription which verifies interface state when change on device.
+
+Command:
+
+pyats run job job_native_test.py -t testbed_native_test.yaml --no-mail --pdb

--- a/blitz_yang_telemetry/job_test.py
+++ b/blitz_yang_telemetry/job_test.py
@@ -1,0 +1,25 @@
+########################################################
+# To run the job:
+# pyats run job  path/to/my/job/file/myjob.py \
+#        -testbed_file path/to/my/yaml/file/myyaml.yaml
+########################################################
+from genie.harness.main import gRun
+
+
+def main():
+    trigger_uids = [
+        'native_oper_interface_statistics_get',
+        'openconfig_gnmi_fan_statistics_subscribe',
+        'native_netconf_cpu_statistics_subscribe',
+        'nexus_openconfig_gnmi_fan_statistics_subscribe',
+        'nexus_netconf_interface_state_subscribe',
+    ]
+
+    gRun(trigger_uids=trigger_uids,
+         trigger_datafile="test_trigger.yaml",
+         mapping_datafile="mapping.yaml",
+         subsection_datafile="subsection.yaml")
+
+
+if __name__ == '__main__':
+    main()

--- a/blitz_yang_telemetry/mapping.yaml
+++ b/blitz_yang_telemetry/mapping.yaml
@@ -1,0 +1,15 @@
+
+devices:
+# WARNING: device name must match configured hostname
+# uut: XE-9500
+# uut2: NX-9000
+    uut:
+        mapping:
+            cli: cli
+            netconf: yang1
+            gnmi: yang2
+    uut2:
+        mapping:
+            cli: cli
+            netconf: yang1
+            gnmi: yang2

--- a/blitz_yang_telemetry/subsection.yaml
+++ b/blitz_yang_telemetry/subsection.yaml
@@ -1,0 +1,9 @@
+
+##############################################################################
+# See Genie User Guide: http://wwwin-pyats.cisco.com/cisco-shared/genie/latest
+setup:
+    sections:
+        connect:
+            method: genie.harness.commons.connect
+    order: ['connect']
+cleanup: {}

--- a/blitz_yang_telemetry/test_trigger.yaml
+++ b/blitz_yang_telemetry/test_trigger.yaml
@@ -1,0 +1,125 @@
+extends: test_trigger_extended.yaml
+
+# It's recommended that you clean up the device before the 
+# profile is executed. To do so, please make sure there's a
+# golden config file on your device, specify the path to that
+# config file below and add this test_prefix task to the job file.
+device_cleanup:
+  source:
+    pkg: genie.libs.sdk
+    class: triggers.blitz.blitz.Blitz
+  test_sections:
+    - apply_configuration:
+      - configure_replace:
+          device: uut
+          config: bootflash:/Golden_config
+
+          # Iteration and interval is used for a retry mechanism
+          iteration: 2  # optional, default is 2
+          interval: 30 # optional, default is 30
+      - sleep:
+          sleep_time: 5
+
+native_oper_interface_statistics_get:
+  source:
+    pkg: genie.libs.sdk
+    class: triggers.blitz.blitz.Blitz
+  test_sections:
+  - verify_yang_return_1:
+    - yang:
+        device: uut
+        connection: '%{ data.yang.connection }'
+        operation: get
+        protocol: '%{ data.yang.protocol }'
+        datastore: '%{ testbed.testbed.custom.datastore }'
+        format: '%{ data.yang.format.2 }'
+        content: '%{ data.yang.content.5 }'
+        returns: '%{ data.yang.returns.1 }'
+        banner: YANG GET
+
+openconfig_gnmi_fan_statistics_subscribe:
+  source:
+    pkg: genie.libs.sdk
+    class: triggers.blitz.blitz.Blitz
+  test_sections:
+  - verify_yang_return_1:
+    - yang:
+        device: uut
+        connection: gnmi
+        operation: subscribe
+        protocol: gnmi
+        datastore: '%{ testbed.testbed.custom.datastore }'
+        format: '%{ data.yang.format.1 }'
+        content: '%{ data.yang.content.1 }'
+        returns: '%{ data.yang.returns.2 }'
+        banner: YANG SUBSCRIBE
+    - execute:
+        device: uut
+        command: show run | sec hostname
+
+native_netconf_cpu_statistics_subscribe:
+  source:
+    pkg: genie.libs.sdk
+    class: triggers.blitz.blitz.Blitz
+  test_sections:
+  - verify_yang_return_1:
+    - yang:
+        device: uut
+        connection: netconf
+        operation: subscribe
+        protocol: netconf
+        datastore: '%{ testbed.testbed.custom.datastore }'
+        format: '%{ data.yang.format.1 }'
+        content: '%{ data.yang.content.2 }'
+        returns: '%{ data.yang.returns.3 }'
+        banner: YANG SUBSCRIBE
+    - execute:
+        device: uut
+        command: show run | sec hostname
+
+nexus_openconfig_gnmi_fan_statistics_subscribe:
+  source:
+    pkg: genie.libs.sdk
+    class: triggers.blitz.blitz.Blitz
+  test_sections:
+  - verify_yang_return_1:
+    - yang:
+        device: uut2
+        connection: gnmi
+        operation: subscribe
+        protocol: gnmi
+        datastore: '%{ testbed.testbed.custom.datastore }'
+        format: '%{ data.yang.format.4 }'
+        content: '%{ data.yang.content.3 }'
+        returns: '%{ data.yang.returns.4 }'
+        banner: YANG SUBSCRIBE
+    - execute:
+        device: uut2
+        command: show run | sec hostname
+
+nexus_netconf_interface_state_subscribe:
+  source:
+    pkg: genie.libs.sdk
+    class: triggers.blitz.blitz.Blitz
+  test_sections:
+  - verify_yang_return_1:
+    - configure:
+        device: uut2
+        command: |
+          int e1/1
+          shutdown
+    - yang:
+        device: uut2
+        connection: netconf
+        operation: subscribe
+        protocol: netconf
+        datastore: '%{ testbed.testbed.custom.datastore }'
+        format: '%{ data.yang.format.3 }'
+        content: '%{ data.yang.content.4 }'
+        returns: '%{ data.yang.returns.5 }'
+        banner: YANG SUBSCRIBE
+    - configure:
+        device: uut2
+        command: |
+          int e1/1
+          no shutdown

--- a/blitz_yang_telemetry/test_trigger_extended.yaml
+++ b/blitz_yang_telemetry/test_trigger_extended.yaml
@@ -1,0 +1,377 @@
+data:
+  configure: {}
+  execute: {}
+  variables:
+    interface_name_1: 'GigabitEthernet0/0'
+  yang:
+    connection: netconf
+    protocol: netconf
+    format:
+      1:
+        request_mode: STREAM
+        sub_mode: SAMPLE
+        encoding: JSON_IETF
+        sample_interval: 5
+        stream_max: 20
+      2:
+        auto_validate: true
+        negative_test: false
+        pause: 0
+        timeout: 30
+      3:
+        request_mode: ON_CHANGE
+        sub_mode: SAMPLE
+        encoding: JSON
+        sample_interval: 0
+        stream_max: 20
+      4:
+        request_mode: STREAM
+        sub_mode: SAMPLE
+        encoding: JSON
+        sample_interval: 5
+        stream_max: 20
+    namespace:
+      1:
+        interfaces-ios-xe-oper: http://cisco.com/ns/yang/Cisco-IOS-XE-interfaces-oper
+        openconfig-system: http://openconfig.net/yang/system
+        oc-platform: http://openconfig.net/yang/platform
+        oc-fan: http://openconfig.net/yang/platform/fan
+    xpath:
+      1: /interfaces-ios-xe-oper:interfaces/interfaces-ios-xe-oper:interface[name="%{ data.variables.interface_name_1 }"]
+      2: /openconfig-system:system/openconfig-system:state
+      3: /oc-platform:components/oc-platform:component[oc-platform:name="Fan1/1"]/oc-platform:fan/oc-platform:state/oc-fan:speed
+      4: /oc-platform:components/oc-platform:component[oc-platform:name="fan1/1"]/oc-platform:fan/oc-platform:state/oc-fan:speed
+    content:
+      1:
+        namespace: '%{ data.yang.namespace.1 }'
+        nodes:
+        - nodetype: ''
+          datatype: ''
+          xpath: '%{ data.yang.xpath.3 }'
+      2:
+        rpc: |
+          <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+            <establish-subscription xmlns="urn:ietf:params:xml:ns:yang:ietf-event-notifications">
+              <stream xmlns:yp="urn:ietf:params:xml:ns:yang:ietf-yang-push">yp:yang-push</stream>
+              <xpath-filter xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push">/process-cpu-ios-xe-oper:cpu-usage/cpu-utilization/five-minutes</xpath-filter>
+              <period xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push">500</period>
+            </establish-subscription>
+          </rpc>
+      3:
+        namespace: '%{ data.yang.namespace.1 }'
+        nodes:
+        - nodetype: ''
+          datatype: ''
+          xpath: '%{ data.yang.xpath.4 }'
+      4:
+        rpc: |
+          <nc:rpc xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="urn:uuid:e2117597-03bb-48c5-9006-de94b1e9f4db">
+            <create-subscription xmlns="urn:ietf:params:xml:ns:yang:ietf-event-notifications">
+              <filter>
+                <System xmlns="http://cisco.com/ns/yang/cisco-nx-os-device">
+                  <intf-items>
+                    <phys-items>
+                      <PhysIf-list>
+                        <id>eth1/1</id>
+                          <phys-items>
+                            <adminSt/>
+                          </phys-items>
+                      </PhysIf-list>
+                    </phys-items>
+                  </intf-items>
+                </System>
+              </filter>
+            </create-subscription>
+          </nc:rpc>
+      5:
+        namespace: '%{ data.yang.namespace.1 }'
+        nodes:
+        - nodetype: 'list'
+          datatype: ''
+          xpath: '%{ data.yang.xpath.1 }'
+    returns:
+      2:
+      - datatype: uint16
+        default: ''
+        name: speed
+        nodetype: ''
+        op: '>'
+        selected: true
+        testbed: ''
+        value: 39000
+        xpath: /components/component/fan/state/speed
+        xpresso: ''
+      3:
+      - datatype: uint16
+        default: ''
+        name: five-minutes
+        nodetype: ''
+        op: ==
+        selected: true
+        testbed: ''
+        value: 0
+        xpath: /notification/push-update/datastore-contents-xml/cpu-usage/cpu-utilization/five-minutes
+        xpresso: ''
+      4:
+      - datatype: uint16
+        default: ''
+        name: speed
+        nodetype: ''
+        op: '>'
+        selected: true
+        testbed: ''
+        value: 8000
+        xpath: /components/component/fan/state/speed
+        xpresso: ''
+      5:
+      - datatype: string
+        default: ''
+        name: adminSt
+        nodetype: ''
+        op: ==
+        selected: true
+        testbed: ''
+        value: 'up'
+        xpath: /notification/event/System/intf-items/phys-items/PhysIf-list/phys-items/adminSt
+        xpresso: ''
+      1:
+      - datatype: string
+        default: ''
+        name: discontinuity-time
+        nodetype: ''
+        op: ==
+        selected: 'False'
+        testbed: ''
+        value: '2021-04-07T21:46:25.041845'
+        xpath: /interfaces/interface/statistics/discontinuity-time
+        xpresso: ''
+      - datatype: uint64
+        default: ''
+        name: in-octets
+        nodetype: ''
+        op: '>'
+        selected: 'True'
+        testbed: ''
+        value: 10000
+        xpath: /interfaces/interface/statistics/in-octets
+        xpresso: ''
+      - datatype: uint64
+        default: ''
+        name: in-unicast-pkts
+        nodetype: ''
+        op: '>'
+        selected: 'True'
+        testbed: ''
+        value: 10000
+        xpath: /interfaces/interface/statistics/in-unicast-pkts
+        xpresso: ''
+      - datatype: uint64
+        default: ''
+        name: in-broadcast-pkts
+        nodetype: ''
+        op: '<'
+        selected: 'True'
+        testbed: ''
+        value: '15'
+        xpath: /interfaces/interface/statistics/in-broadcast-pkts
+        xpresso: ''
+      - datatype: uint64
+        default: ''
+        name: in-multicast-pkts
+        nodetype: ''
+        op: '>'
+        selected: 'True'
+        testbed: ''
+        value: '15'
+        xpath: /interfaces/interface/statistics/in-multicast-pkts
+        xpresso: ''
+      - datatype: uint32
+        default: ''
+        name: in-discards
+        nodetype: ''
+        op: ==
+        selected: 'True'
+        testbed: ''
+        value: 0
+        xpath: /interfaces/interface/statistics/in-discards
+        xpresso: ''
+      - datatype: uint32
+        default: ''
+        name: in-errors
+        nodetype: ''
+        op: ==
+        selected: 'True'
+        testbed: ''
+        value: 0
+        xpath: /interfaces/interface/statistics/in-errors
+        xpresso: ''
+      - datatype: uint32
+        default: ''
+        name: in-unknown-protos
+        nodetype: ''
+        op: ==
+        selected: 'True'
+        testbed: ''
+        value: 0
+        xpath: /interfaces/interface/statistics/in-unknown-protos
+        xpresso: ''
+      - datatype: uint32
+        default: ''
+        name: out-octets
+        nodetype: ''
+        op: '>'
+        selected: 'True'
+        testbed: ''
+        value: 10000
+        xpath: /interfaces/interface/statistics/out-octets
+        xpresso: ''
+      - datatype: uint64
+        default: ''
+        name: out-unicast-pkts
+        nodetype: ''
+        op: '>'
+        selected: 'True'
+        testbed: ''
+        value: 10000
+        xpath: /interfaces/interface/statistics/out-unicast-pkts
+        xpresso: ''
+      - datatype: uint64
+        default: ''
+        name: out-broadcast-pkts
+        nodetype: ''
+        op: '<'
+        selected: 'True'
+        testbed: ''
+        value: '15'
+        xpath: /interfaces/interface/statistics/out-broadcast-pkts
+        xpresso: ''
+      - datatype: uint64
+        default: ''
+        name: out-multicast-pkts
+        nodetype: ''
+        op: ==
+        selected: 'False'
+        testbed: ''
+        value: '15'
+        xpath: /interfaces/interface/statistics/out-multicast-pkts
+        xpresso: ''
+      - datatype: uint64
+        default: ''
+        name: out-discards
+        nodetype: ''
+        op: ==
+        selected: 'False'
+        testbed: ''
+        value: '15'
+        xpath: /interfaces/interface/statistics/out-discards
+        xpresso: ''
+      - datatype: uint64
+        default: ''
+        name: out-errors
+        nodetype: ''
+        op: ==
+        selected: 'False'
+        testbed: ''
+        value: '15'
+        xpath: /interfaces/interface/statistics/out-errors
+        xpresso: ''
+      - datatype: uint64
+        default: ''
+        name: rx-pps
+        nodetype: ''
+        op: ==
+        selected: 'False'
+        testbed: ''
+        value: '15'
+        xpath: /interfaces/interface/statistics/rx-pps
+        xpresso: ''
+      - datatype: uint64
+        default: ''
+        name: rx-kbps
+        nodetype: ''
+        op: ==
+        selected: 'False'
+        testbed: ''
+        value: '15'
+        xpath: /interfaces/interface/statistics/rx-kbps
+        xpresso: ''
+      - datatype: uint64
+        default: ''
+        name: tx-pps
+        nodetype: ''
+        op: ==
+        selected: 'False'
+        testbed: ''
+        value: '15'
+        xpath: /interfaces/interface/statistics/tx-pps
+        xpresso: ''
+      - datatype: uint64
+        default: ''
+        name: tx-kbps
+        nodetype: ''
+        op: ==
+        selected: 'False'
+        testbed: ''
+        value: '15'
+        xpath: /interfaces/interface/statistics/tx-kbps
+        xpresso: ''
+      - datatype: uint64
+        default: ''
+        name: num-flaps
+        nodetype: ''
+        op: ==
+        selected: 'False'
+        testbed: ''
+        value: '15'
+        xpath: /interfaces/interface/statistics/num-flaps
+        xpresso: ''
+      - datatype: uint64
+        default: ''
+        name: in-crc-errors
+        nodetype: ''
+        op: ==
+        selected: 'False'
+        testbed: ''
+        value: '15'
+        xpath: /interfaces/interface/statistics/in-crc-errors
+        xpresso: ''
+      - datatype: uint64
+        default: ''
+        name: in-discards-64
+        nodetype: ''
+        op: ==
+        selected: 'False'
+        testbed: ''
+        value: '15'
+        xpath: /interfaces/interface/statistics/in-discards-64
+        xpresso: ''
+      - datatype: uint64
+        default: ''
+        name: in-errors-64
+        nodetype: ''
+        op: ==
+        selected: 'False'
+        testbed: ''
+        value: '15'
+        xpath: /interfaces/interface/statistics/in-errors-64
+        xpresso: ''
+      - datatype: uint64
+        default: ''
+        name: in-unknown-protos-64
+        nodetype: ''
+        op: ==
+        selected: 'False'
+        testbed: ''
+        value: '15'
+        xpath: /interfaces/interface/statistics/in-unknown-protos-64
+        xpresso: ''
+      - datatype: uint64
+        default: ''
+        name: out-octets-64
+        nodetype: ''
+        op: ==
+        selected: 'False'
+        testbed: ''
+        value: '15'
+        xpath: /interfaces/interface/statistics/out-octets-64
+        xpresso: ''

--- a/blitz_yang_telemetry/testbed_native_test.yaml
+++ b/blitz_yang_telemetry/testbed_native_test.yaml
@@ -1,0 +1,76 @@
+testbed: # Add device related variable key/values under "custom".
+    name: ddmi-9500-2
+    custom:
+        datastore:
+            type: ''
+            lock: true
+            retry: 40
+        interface_name_1: 
+devices:
+    # WARNING: device name must match configured hostname
+    ddmi-9500-2:
+        type: iosxe
+        os: iosxe
+        alias: uut
+        credentials:
+            default:
+                username: admin
+                password: admin
+        connections:
+            cli:
+                class: unicon.Unicon
+                protocol: ssh
+                ip: 192.168.255.22
+                port: 22
+            yang1:
+                class: yang.connector.Netconf
+                protocol: netconf
+                host: 192.168.255.22
+                port: 830
+                # set all these to False if you have SSH key issues
+                hostkey_verify: False
+                look_for_keys: True
+                allow_agent: True
+            yang2:
+                class: yang.connector.Gnmi
+                protocol: gnmi
+                host: 192.168.255.22
+                # port: 50052
+                port: 9339
+                root_certificate: '/Users/example/certs/iosxe/ddmi-9500-2/rootCA.pem'
+                private_key: '/Users/example/certs/iosxe/ddmi-9500-2/client.key'
+                certificate_chain: '/Users/example/certs/iosxe/ddmi-9500-2/client.crt'
+                ssl_name_override: xe9k.cisco.com
+    nx-dmi-36:
+        type: n9k
+        os: nxos
+        alias: uut2
+        credentials:
+            default:
+                username: admin
+                password: admin
+        connections:
+            cli:
+                class: unicon.Unicon
+                protocol: ssh
+                ip: 192.168.255.36
+                port: 22
+            yang1:
+                class: yang.connector.Netconf
+                protocol: netconf
+                host: 192.168.255.36
+                port: 830
+                # set all these to False if you have SSH key issues
+                hostkey_verify: False
+                look_for_keys: True
+                allow_agent: True
+            yang2:
+                class: yang.connector.Gnmi
+                protocol: gnmi
+                host: 192.168.255.36
+                port: 50051
+                root_certificate: '/Users/example/certs/nxos/nx-dmi-36/server-cert-chain.pem'
+                private_key: ''
+                certificate_chain: ''
+                ssl_name_override: nx-dmi-36.cisco.com
+


### PR DESCRIPTION
Long overdue test example for testing YANG subscribe functionality used in telemetry for NETCONF and gNMI.